### PR TITLE
Bugfix: wrong values for machine operating modes

### DIFF
--- a/custom_components/airzone/const.py
+++ b/custom_components/airzone/const.py
@@ -83,13 +83,15 @@ LOCALAPI_MACHINE_HVAC_MODES = [HVAC_MODE_OFF,
                             HVAC_MODE_DRY,
                             HVAC_MODE_AUTO] 
 
+from airzone.localapi import OperationMode
+
 LOCALAPI_HVAC_MODE_MAP = {
-    HVAC_MODE_OFF:'STOP',
-    HVAC_MODE_COOL:'COOLING',    
-    HVAC_MODE_HEAT:'HEATING',
-    HVAC_MODE_FAN_ONLY:'FAN',
-    HVAC_MODE_DRY:'DRY',
-    HVAC_MODE_AUTO:'AUTO',
+    HVAC_MODE_OFF: OperationMode.STOP,
+    HVAC_MODE_COOL: OperationMode.COOLING,
+    HVAC_MODE_HEAT: OperationMode.HEATING,
+    HVAC_MODE_FAN_ONLY: OperationMode.FAN,
+    HVAC_MODE_DRY: OperationMode.DRY,
+    HVAC_MODE_AUTO: OperationMode.AUTO
 }
 
 LOCALAPI_MODE_TO_HVAC_MAP = {


### PR DESCRIPTION
First of all, thank you for the implementation.

I found a bug that affected the possibility of changing the operating mode of the airzone system. Regardeless of the selected mode, my machine switched to "STOP".

I investigated the problem and I found that the API sends out a string instead of the ID of the operating mode (e.g. "COOL" instead of 2).

The mods in the pull request fixed my issue.